### PR TITLE
opendatahub-io/ai-edge: Unlink GitHub reviews from /approve and /lgtm plugins

### DIFF
--- a/core-services/prow/02_config/opendatahub-io/ai-edge/_pluginconfig.yaml
+++ b/core-services/prow/02_config/opendatahub-io/ai-edge/_pluginconfig.yaml
@@ -3,6 +3,7 @@ approve:
   repos:
   - opendatahub-io/ai-edge
   require_self_approval: true
+  ignore_review_state: true
 external_plugins:
   opendatahub-io/ai-edge:
   - endpoint: http://refresh
@@ -36,7 +37,7 @@ external_plugins:
 lgtm:
 - repos:
   - opendatahub-io/ai-edge
-  review_acts_as_lgtm: true
+  review_acts_as_lgtm: false
 plugins:
   opendatahub-io/ai-edge:
     plugins:


### PR DESCRIPTION
Changes:
- `ignore_review_state: true` configures GitHub reviews to not call `/approve` or `/approve cancel` when the review is approving or requesting changes, respectively
-  `review_acts_as_lgtm: false` configures GitHub reviews to not call `/lgtm` or `/lgtm cancel` when the review is approving or requesting changes, respectively