### PR TITLE
opendatahub-io/ai-edge: Fix formatting of _pluginconfig.yaml

### DIFF
--- a/core-services/prow/02_config/opendatahub-io/ai-edge/_pluginconfig.yaml
+++ b/core-services/prow/02_config/opendatahub-io/ai-edge/_pluginconfig.yaml
@@ -1,9 +1,9 @@
 approve:
 - commandHelpLink: ""
+  ignore_review_state: true
   repos:
   - opendatahub-io/ai-edge
   require_self_approval: true
-  ignore_review_state: true
 external_plugins:
   opendatahub-io/ai-edge:
   - endpoint: http://refresh
@@ -37,7 +37,6 @@ external_plugins:
 lgtm:
 - repos:
   - opendatahub-io/ai-edge
-  review_acts_as_lgtm: false
 plugins:
   opendatahub-io/ai-edge:
     plugins:


### PR DESCRIPTION
`review_acts_as_lgtm: false` is the default, hence the removal.